### PR TITLE
Update VideoBlob Scopes and CreateMkvService Logic for Enhanced Video Management

### DIFF
--- a/app/models/video_blob.rb
+++ b/app/models/video_blob.rb
@@ -81,7 +81,7 @@ class VideoBlob < ApplicationRecord
   scope :optimized, -> { where(optimized: true) }
   scope :uploadable, -> { where(uploadable: true) }
   scope :uploaded, -> { where(uploadable: false).where.not(uploaded_on: nil) }
-  scope :uploaded_recently, -> { where(arel_table[:uploaded_on].gteq(1.minute.ago)) }
+  scope :uploaded_recently, -> { where(arel_table[:uploaded_on].gteq(10.minutes.ago)) }
 
   delegate :title, :year, :episode, :season, to: :parsed, allow_nil: true, prefix: true
   delegate :plex_name, to: :video, prefix: true, allow_nil: true

--- a/app/services/create_mkv_service.rb
+++ b/app/services/create_mkv_service.rb
@@ -58,11 +58,19 @@ class CreateMkvService < ApplicationService
   end
 
   def video_blob
-    @video_blob ||= VideoBlob.find_or_create_by!(
-      video: disk_title.video,
-      episode: disk_title.episode,
-      extra_type: extra_type.presence || :feature_films
-    )
+    @video_blob ||= if extra_type == 'feature_films' || extra_type.blank?
+                      VideoBlob.find_or_create_by!(
+                        video: disk_title.video,
+                        episode: disk_title.episode,
+                        extra_type: extra_type.presence || :feature_films
+                      )
+                    else
+                      VideoBlob.create!(
+                        video: disk_title.video,
+                        episode: disk_title.episode,
+                        extra_type:
+                      )
+                    end
   end
 
   def recreate_dir(dir)

--- a/spec/models/video_blob_spec.rb
+++ b/spec/models/video_blob_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe VideoBlob do
     it { is_expected.to have_scope(:uploadable).where(uploadable: true) }
 
     it {
-      expect(subject).to have_scope(:uploaded_recently).where(described_class.arel_table[:uploaded_on].gteq(1.minute.ago))
+      expect(subject).to have_scope(:uploaded_recently).where(described_class.arel_table[:uploaded_on].gteq(10.minutes.ago))
     }
   end
 


### PR DESCRIPTION
The Git diff shows the following changes:

1. **`app/models/video_blob.rb`**:
   - The `uploaded_recently` scope's time condition has been modified. It previously checked if `uploaded_on` was greater than or equal to 1 minute ago. Now, it checks for 10 minutes ago.

2. **`app/services/create_mkv_service.rb`**:
   - The logic for finding or creating a `VideoBlob` has been updated. The method now has a conditional structure where if the `extra_type` is 'feature_films' or blank, it uses the `find_or_create_by!` method with default parameters. If `extra_type` is present and not 'feature_films', it creates a new `VideoBlob` with the specified `extra_type`.

3. **`spec/models/video_blob_spec.rb`**:
   - The tests for the `uploaded_recently` scope have been updated to reflect the change from 1 minute to 10 minutes for the `uploaded_on` condition.