### PR TITLE
Refactor Video Blob Checks and Improve Redirect Logic in Movie and Season Views

### DIFF
--- a/app/components/movie_title_table_component.html.erb
+++ b/app/components/movie_title_table_component.html.erb
@@ -34,7 +34,7 @@
             </td>
             <td class="text-center">
               <h1>
-                <% if disk_title.video_blob&.uploaded? %>
+                <% if movie.ripped_disk_titles.any? { _1.video_blob&.uploaded? } %>
                   <%= icon('square-check') %>
                 <% else %>
                   <%= icon('square') %>

--- a/app/views/seasons/show.html.erb
+++ b/app/views/seasons/show.html.erb
@@ -48,7 +48,7 @@
           </td>
           <td class="text-center">
             <h1>
-              <% if episode.video_blobs.any?(&:uploaded?) %>
+              <% if episode.ripped_disk_titles.any? { _1.video_blob.uploaded? } %>
                 <%= icon('square-check') %>
               <% else %>
                 <%= icon('square') %>

--- a/app/workers/rip_worker.rb
+++ b/app/workers/rip_worker.rb
@@ -55,10 +55,16 @@ class RipWorker < ApplicationWorker
   end
 
   def redirect_url
-    if disk.video.is_a?(Movie)
-      movie_url(disk.video)
-    elsif disk.video.is_a?(Tv)
-      tv_season_url(disk.episode.season.tv, disk.episode.season)
+    disk_title = DiskTitle.find(disk_title_ids.first)
+    if disk_title.video.is_a?(Movie)
+      movie_url(disk_title.video)
+    elsif disk_title.video.is_a?(Tv)
+      tv_season_url(disk_title.episode.season.tv, disk_title.episode.season)
     end
+  end
+
+  def reload_page!
+    cable_ready[BroadcastChannel.channel_name].reload
+    cable_ready.broadcast
   end
 end

--- a/app/workers/rip_worker.rb
+++ b/app/workers/rip_worker.rb
@@ -55,7 +55,9 @@ class RipWorker < ApplicationWorker
   end
 
   def redirect_url
-    disk_title = DiskTitle.find(disk_title_ids.first)
+    disk_title = DiskTitle.find_by(id: disk_title_ids.first)
+    return if disk_title.nil?
+
     if disk_title.video.is_a?(Movie)
       movie_url(disk_title.video)
     elsif disk_title.video.is_a?(Tv)


### PR DESCRIPTION
Here is a summary of the changes made in the Git PR:

1. **Modified `app/components/movie_title_table_component.html.erb`:**
    - Updated the logic within a table cell to check for uploaded video blobs in disk titles.
    - Added a condition to display a checked or unchecked icon based on whether any ripped disk titles have uploaded video blobs.

2. **Modified `app/views/seasons/show.html.erb`:**
    - Adjusted the logic within a table cell to check for uploaded video blobs in episodes.
    - Added a condition to display a checked or unchecked icon based on whether any ripped disk titles of the episode have uploaded video blobs.

3. **Modified `app/workers/rip_worker.rb`:**
    - Refactored the `redirect_url` method to use `disk_title` instead of `disk`.
    - Added a new `disk_title` assignment to find the first disk title.
    - Updated the URL generation logic to handle both movies and TV episodes.
    - Included a `reload_page!` method using `cable_ready` to reload the page via the `BroadcastChannel`.

These changes improve the logic for checking uploaded video blobs and ensure appropriate icons are displayed, while also refactoring the `redirect_url` method for better handling of disk titles.